### PR TITLE
implemented page navigation on form query submit

### DIFF
--- a/src/components/hero/JobSearchForm.vue
+++ b/src/components/hero/JobSearchForm.vue
@@ -1,6 +1,8 @@
 <template>
   <form
     class="flex items-center w-full h-12 mt-14 border border-solid border-gray-3 rounded-3xl"
+    data-test="form-submit"
+    @submit.prevent="searchJobs"
   >
     <font-awesome-icon :icon="['fas', 'search']" class="ml-4 mr-3" />
 
@@ -14,7 +16,11 @@
           :form-value="job_type"
           @form-input="getJobType"
         ></text-input> -->
-        <text-input v-model="job_type" placeholder="job type"></text-input>
+        <text-input
+          v-model="job_type"
+          placeholder="job type"
+          data-test="job-type-input"
+        ></text-input>
       </div>
       <span
         class="flex items-center h-full px-3 border-x border-gray-3 bg-gray-2"
@@ -32,6 +38,7 @@
           v-model="location"
           type="text"
           placeholder="city"
+          data-test="location-input"
         ></text-input>
       </div>
     </div>
@@ -66,6 +73,13 @@ export default {
     },
     getLocation(value) {
       this.location = value;
+    },
+    searchJobs() {
+      const query = {
+        job_type: this.job_type,
+        location: this.location,
+      };
+      this.$router.push({ name: "JobResults", query });
     },
   },
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,12 +1,19 @@
 import { createRouter, createWebHashHistory } from "vue-router";
-import HomeView from "@/views/HomeView.vue";
-import JobResultsView from "@/views/JobResultsView.vue";
+
+/* =lazy load the components= */
+const HomeView = () => import("@/views/HomeView.vue");
+const JobResults = () =>
+  import(/* webpackCHunkName: "jobs" */ "@/views/JobResultsView.vue");
+const JobPage = () =>
+  import(/* webpackCHunkName: "jobs" */ "@/views/JobView.vue");
+/* ========================== */
 
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
     { path: "/", name: "Home", component: HomeView },
-    { path: "/jobs/results", name: "JobResults", component: JobResultsView },
+    { path: "/jobs/results", name: "JobResults", component: JobResults },
+    { path: "/jobs/results/:id", name: "JobPage", component: JobPage },
   ],
 });
 

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>Job Page</div>
+  {{ jobID }}
+</template>
+
+<script>
+export default {
+  name: "JobView",
+  computed: {
+    jobID() {
+      return this.$route.params.id;
+    },
+  },
+};
+</script>

--- a/tests/unit/components/jobs/JobSearchForm.test.js
+++ b/tests/unit/components/jobs/JobSearchForm.test.js
@@ -1,0 +1,49 @@
+import { mount } from "@vue/test-utils";
+import JobSearchForm from "@/components/hero/JobSearchForm.vue";
+
+describe("JobSearchForm", () => {
+  describe("when user submits form", () => {
+    it("navigates to the jobs result page", async () => {
+      // mock the this.$router method in our test environment
+      const push = jest.fn();
+      const $router = { push };
+
+      const wrapper = mount(JobSearchForm, {
+        attachTo: document.body,
+        global: {
+          mocks: {
+            $router,
+          },
+          stubs: {
+            FontAwesomeIcon: true,
+          },
+        },
+      });
+
+      // job type input
+      const job_type_input = wrapper.find("[data-test='job-type-input']");
+      await job_type_input.setValue("Frontend Developer");
+
+      // location input
+      const location_input = wrapper.find("[data-test='location-input']");
+      await location_input.setValue("Ibadan");
+
+      // submit btn
+      const submit = wrapper.find("[data-test='form-submit']");
+
+      // mimic submit btn
+      await submit.trigger("submit");
+
+      // assert that the push method on the $router has been called
+      const query = {
+        job_type: "Frontend Developer",
+        location: "Ibadan",
+      };
+
+      expect(push).toHaveBeenCalledWith({
+        name: "JobResults",
+        query,
+      });
+    });
+  });
+});


### PR DESCRIPTION
When a search is made on the home page, the router leads to the JobResults plage (on "/jobs/results" route) using the vue-router $router method.

Carried out test on the JobForm by mocking the $route.push() with jest.fn() to decouple the Vue router implementation with our own simpler JS object to achieve the task of mimicking routing.